### PR TITLE
Fixing public key retrieval after API change

### DIFF
--- a/src/main/java/cloud/fogbow/fns/core/PublicKeysHolder.java
+++ b/src/main/java/cloud/fogbow/fns/core/PublicKeysHolder.java
@@ -12,6 +12,7 @@ import cloud.fogbow.fns.constants.ConfigurationPropertyKeys;
 import cloud.fogbow.fns.constants.ConfigurationPropertyDefaults;
 import cloud.fogbow.fns.constants.Messages;
 import cloud.fogbow.ras.api.http.request.PublicKey;
+import com.google.gson.Gson;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.HttpResponseException;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -21,6 +22,7 @@ import java.net.URISyntaxException;
 import java.security.GeneralSecurityException;
 import java.security.interfaces.RSAPublicKey;
 import java.util.HashMap;
+import java.util.Map;
 
 public class PublicKeysHolder {
     private HttpRequestClientUtil client;
@@ -82,7 +84,10 @@ public class PublicKeysHolder {
             throw new UnavailableProviderException(e.getMessage(), e);
         } else {
             try {
-                publicKey = RSAUtil.getPublicKeyFromString(response.getContent());
+                Gson gson = new Gson();
+                Map<String, String> jsonResponse = gson.fromJson(response.getContent(), HashMap.class);
+                String publicKeyString = jsonResponse.get("publicKey");
+                publicKey = RSAUtil.getPublicKeyFromString(publicKeyString);
             } catch (GeneralSecurityException e) {
                 throw new UnexpectedException(Messages.Exception.INVALID_PUBLIC_KEY);
             }


### PR DESCRIPTION
This is done by parsing the generic response as a JSON object.