### PR TITLE
Fix delete compute

### DIFF
--- a/src/main/java/cloud/fogbow/fns/constants/ApiDocumentation.java
+++ b/src/main/java/cloud/fogbow/fns/constants/ApiDocumentation.java
@@ -35,7 +35,7 @@ public class ApiDocumentation {
     public static class Model {
         public static final String INSTANCE_ID = "9632af26-72ee-461a-99a9-1e5d59076a98";
         public static final String INSTANCE_NAME = "instance name";
-        public static final String PROVIDERS = "provider1.domain1, provider2.domain2";
+        public static final String PROVIDERS = "[\"provider1.domain1\", \"provider2.domain2\"]";
         public static final String REQUESTER = "requester.domain";
         public static final String PROVIDER = "provider.domain";
         public static final String COMPUTE_LIST = "[\n" +

--- a/src/main/java/cloud/fogbow/fns/core/ApplicationFacade.java
+++ b/src/main/java/cloud/fogbow/fns/core/ApplicationFacade.java
@@ -210,7 +210,8 @@ public class ApplicationFacade {
         this.computeRequestsController.removeIpToComputeAllocation(computeId);
 
         if (federatedNetworkOrder != null) {
-            String hostIp = this.getComputeIpFromDefaultNetwork(computeInstance.getIpAddresses());
+            String hostIp = federatedNetworkOrder.getConfigurationMode().equals(ConfigurationMode.DFNS) ?
+                    this.getComputeIpFromDefaultNetwork(computeInstance.getIpAddresses()) : null;
 
             this.removeAgentToComputeTunnel(federatedNetworkOrder, computeInstance.getProvider(), hostIp);
         }


### PR DESCRIPTION
This change fixes a bug where FNS would throw a NullPointerException in
case the compute instance to be deleted was associated to a fednet.
Also, fixes API documentation for the create fednet request.