### PR TITLE
Fix get compute

### DIFF
--- a/src/main/java/cloud/fogbow/fns/core/ApplicationFacade.java
+++ b/src/main/java/cloud/fogbow/fns/core/ApplicationFacade.java
@@ -28,6 +28,7 @@ import cloud.fogbow.fns.utils.RedirectToRasUtil;
 import cloud.fogbow.ras.api.http.ExceptionResponse;
 import cloud.fogbow.ras.api.http.request.Compute;
 import cloud.fogbow.ras.api.http.response.ComputeInstance;
+import cloud.fogbow.ras.api.http.response.InstanceState;
 import cloud.fogbow.ras.core.models.UserData;
 import com.google.gson.Gson;
 import org.apache.commons.net.util.SubnetUtils;
@@ -292,9 +293,11 @@ public class ApplicationFacade {
         String defaultNetworkCidr = PropertiesHolder.getInstance().getProperty(ConfigurationPropertyKeys.DEFAULT_NETWORK_CIDR_KEY);
         SubnetUtils.SubnetInfo subnetInfo = FederatedNetworkUtil.getSubnetInfo(defaultNetworkCidr);
 
-        for (String ip : computeIps) {
-            if (subnetInfo.isInRange(ip)) {
-                return ip;
+        if (computeIps != null) {
+            for (String ip : computeIps) {
+                if (subnetInfo.isInRange(ip)) {
+                    return ip;
+                }
             }
         }
 

--- a/src/main/java/cloud/fogbow/fns/core/ComputeRequestsController.java
+++ b/src/main/java/cloud/fogbow/fns/core/ComputeRequestsController.java
@@ -36,7 +36,7 @@ public class ComputeRequestsController {
             FederatedNetworkOrder federatedNetworkOrder = FederatedNetworkOrdersHolder.getInstance().
                     getFederatedNetworkOrder(federatedNetworkId);
             String instanceIp = federatedNetworkOrder.getAssociatedIp(computeId);
-            if (instanceIp != null) {
+            if (instanceIp != null && computeInstance.getIpAddresses() != null) {
                 computeInstance.getIpAddresses().add(instanceIp);
             }
         }


### PR DESCRIPTION
This change fixes a bug where a NullPointerException is thrown when
trying to get or delete a failed/error compute order . This is due to attempting to access
a null IP addresses list for the compute order.